### PR TITLE
Added support for xcode 4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    autotest-fsevent (0.2.5)
+    autotest-fsevent (0.2.7)
       sys-uname
 
 GEM
@@ -9,6 +9,7 @@ GEM
   specs:
     ZenTest (4.5.0)
     diff-lcs (1.1.2)
+    ffi (1.0.11)
     rake (0.8.7)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
@@ -18,7 +19,8 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
-    sys-uname (0.8.5)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/ext/fsevent/extconf.rb
+++ b/ext/fsevent/extconf.rb
@@ -32,6 +32,9 @@ if ENV.has_key?('FSEVENT_SLEEP')
 elsif File.exists?('/Developer/Applications/Xcode.app')
   `CFLAGS='-isysroot /Developer/SDKs/MacOSX#{SDK_VERSION}.sdk -mmacosx-version-min=#{SDK_VERSION}' /usr/bin/gcc -framework CoreServices -o "#{GEM_ROOT}/bin/fsevent_sleep" fsevent_sleep.c`
   raise "\e[1;31mCompilation of fsevent_sleep binary failed - see README for assistance\e[0m" unless File.executable?("#{GEM_ROOT}/bin/fsevent_sleep")
+elsif File.exists?('/Applications/Xcode.app') # Xcode 4.3
+  `CFLAGS='-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX#{SDK_VERSION}.sdk -mmacosx-version-min=#{SDK_VERSION}' /usr/bin/gcc -framework CoreServices -o "#{GEM_ROOT}/bin/fsevent_sleep" fsevent_sleep.c`
+  raise "\e[1;31mCompilation of fsevent_sleep binary failed - see README for assistance\e[0m" unless File.executable?("#{GEM_ROOT}/bin/fsevent_sleep")
 else
   raise "\e[1;31mXcode not found - see README for assistance\e[0m"
 end


### PR DESCRIPTION
Xcode 4.3 installs into /Applications/Xcode.app and has MacOSX SDKs in /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs.
