### PR TITLE
Add Mavericks support

### DIFF
--- a/ext/fsevent/extconf.rb
+++ b/ext/fsevent/extconf.rb
@@ -19,7 +19,7 @@ emulate_extension_install('fsevent')
 if `uname -s`.chomp == 'Darwin'
   GEM_ROOT       = File.expand_path(File.join('..', '..'))
   DARWIN_VERSION = `uname -r`.to_i
-  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8' }[DARWIN_VERSION]
+  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8', 13 => '10.9' }[DARWIN_VERSION]
   
   raise "Darwin #{DARWIN_VERSION} is not (yet) supported" unless SDK_VERSION
   


### PR DESCRIPTION
People are unable to build autotest-fsevent on Mavericks: http://stackoverflow.com/a/19798442/95683

This change lets the gem build. I'm not sure if there are any additional implications.
