### PR TITLE
Include Yosemite

### DIFF
--- a/ext/fsevent/extconf.rb
+++ b/ext/fsevent/extconf.rb
@@ -19,7 +19,7 @@ emulate_extension_install('fsevent')
 if `uname -s`.chomp == 'Darwin'
   GEM_ROOT       = File.expand_path(File.join('..', '..'))
   DARWIN_VERSION = `uname -r`.to_i
-  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8', 13 => '10.9' }[DARWIN_VERSION]
+  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8', 13 => '10.9', 14 => '10.10' }[DARWIN_VERSION]
   
   raise "Darwin #{DARWIN_VERSION} is not (yet) supported" unless SDK_VERSION
   


### PR DESCRIPTION
Without this, yosemite users get the following error in extconf.rb:

```
Darwin 14 is not (yet) supported
```
