### PR TITLE
Support for macOS Sierra

### DIFF
--- a/ext/fsevent/extconf.rb
+++ b/ext/fsevent/extconf.rb
@@ -19,8 +19,8 @@ emulate_extension_install('fsevent')
 if `uname -s`.chomp == 'Darwin'
   GEM_ROOT       = File.expand_path(File.join('..', '..'))
   DARWIN_VERSION = `uname -r`.to_i
-  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8', 13 => '10.9', 14 => '10.10', 15 => '10.11' }[DARWIN_VERSION]
-  
+  SDK_VERSION    = { 9 => '10.5', 10 => '10.6', 11 => '10.7', 12 => '10.8', 13 => '10.9', 14 => '10.10', 15 => '10.11', 16 => '10.12' }[DARWIN_VERSION]
+
   raise "Darwin #{DARWIN_VERSION} is not (yet) supported" unless SDK_VERSION
   
   `mkdir -p #{File.join(GEM_ROOT, 'bin')}`


### PR DESCRIPTION
This follows the patterns in https://github.com/svoop/autotest-fsevent/pull/9 to add support for macOS Sierra.