### PR TITLE
Use `File#exist?` for Ruby 3.2+ compatibility

### DIFF
--- a/ext/fsevent/extconf.rb
+++ b/ext/fsevent/extconf.rb
@@ -26,10 +26,10 @@ if `uname -s`.chomp == 'Darwin'
     require 'fileutils'
     FileUtils.cp(ENV['FSEVENT_SLEEP'], "#{gem_root}/bin/fsevent_sleep", :preserve => true)
     fail "Installation of fsevent_sleep binary failed - see README for assistance" unless File.executable?("#{gem_root}/bin/fsevent_sleep")
-  elsif File.exists?('/Developer/Applications/Xcode.app')
+  elsif File.exist?('/Developer/Applications/Xcode.app')
     `CFLAGS='-isysroot /Developer/SDKs/MacOSX#{sdk_version}.sdk -mmacosx-version-min=#{sdk_version}' /usr/bin/gcc -framework CoreServices -o "#{gem_root}/bin/fsevent_sleep" fsevent_sleep.c`
     fail "Compilation of fsevent_sleep binary failed - see README for assistance" unless File.executable?("#{gem_root}/bin/fsevent_sleep")
-  elsif File.exists?('/Applications/Xcode.app') # Xcode 4.3
+  elsif File.exist?('/Applications/Xcode.app') # Xcode 4.3
     `CFLAGS='-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX#{sdk_version}.sdk -mmacosx-version-min=#{sdk_version}' /usr/bin/gcc -framework CoreServices -o "#{gem_root}/bin/fsevent_sleep" fsevent_sleep.c`
     fail "Compilation of fsevent_sleep binary failed - see README for assistance" unless File.executable?("#{gem_root}/bin/fsevent_sleep")
   else


### PR DESCRIPTION
Installation of `autotest-fsevent` with Ruby 3.2.0+ is currently failing with the

    extconf.rb:29:in `<main>': undefined method `exists?' for File:Class (NoMethodError)

error. This is due to the fact that [deprecated `Dir.exists?` and `File.exists?` have been removed in Ruby 3.2.0](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2).

This PR fixes the issue by replacing `File.exists?` with `File.exist?` that's [compatible with Ruby 1.8.7](https://ruby-doc.org/core-1.8.7/File.html#method-c-exist-3F) as well as [Ruby 3.2+](https://ruby-doc.org/3.2.2/File.html#method-c-exist-3F).